### PR TITLE
added github ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: Build PCB
+on: [push]
+jobs:
+  Build-pcb:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Mark github workspace as safe
+        run: git config --global --add safe.directory "$PWD"
+      - name: Build PCB
+        uses: INTI-CMNB/KiBot@v2_k8
+        with:
+          config: kibot.yaml
+          dir: output
+          schema: bitaxeGamma.kicad_sch
+      - name: Archive outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: output
+          path: output

--- a/.kibot/mfg_common.kibot.yaml
+++ b/.kibot/mfg_common.kibot.yaml
@@ -1,0 +1,37 @@
+# This is a working example.
+# For a more complete reference use `--example`
+kibot:
+  version: 1
+
+
+outputs:
+
+- name: basic_gerb_drill
+  comment: Drill files in GERB_DRILL format
+  type: gerb_drill
+  dir: gerber/drill
+  options:
+    map: gerber
+
+- name: basic_excellon
+  comment: Drill files in EXCELLON format
+  type: excellon
+  dir: gerber/drill
+  options:
+    map: pdf
+
+- name: basic_position_CSV
+  comment: Components position for Pick & Place
+  type: position
+  dir: position
+  options:
+    format: CSV
+    only_smd: true
+
+- name: report_full
+  comment: Full design report
+  type: report
+  options:
+    template: full_SVG
+    do_convert: true
+

--- a/.kibot/mfg_jlcpcb.kibot.yaml
+++ b/.kibot/mfg_jlcpcb.kibot.yaml
@@ -1,0 +1,164 @@
+# This KiBot script generates gerbers, drill, bom, and position files for submitting
+# two layer boards to JLCPCB.
+variants:
+  - name: rotated
+    comment: "Just a place holder for the rotation filter"
+    type: kibom
+    variant: rotated
+    pre_transform: fix_rotation
+
+filters:
+  - name: only_jlc_parts
+    comment: "Only parts with JLC code"
+    type: generic
+    include_only:
+      - column: "LCSC"
+        regex: '^C\d+'
+  - name: fix_rotation
+    comment: "Adjust rotation for JLC"
+    type: rot_footprint
+    negative_bottom: true
+    # Rotation list from https://github.com/matthewlai/JLCKicadTools/blob/master/jlc_kicad_tools/cpl_rotations_db.csv
+    rotations:
+      - ["^R_Array_Convex_", 90]
+      - ["^R_Array_Concave_", 90]
+      - ["^SOT-223", 180]
+      - ["^SOT-23", 180]
+      - ["^SOT-89", 180]
+      - ["^TSOT-23", 180]
+      - ["^SOT-353", 180]
+      - ["^SOT-363", 180]
+      - ["^QFN-", 270]
+      - ["^LQFP-", 270]
+      - ["^TQFP-", 270]
+      - ["^SOP-4_", 0]
+      - ["^SOP-(?!18_)", 270]
+      - ["^TSSOP-", 270]
+      - ["^SSOP-", 270]
+      - ["^DFN-", 270]
+      - ["^SOIC-", 270]
+      - ["^SOP-18_", 0]
+      - ["^VSSOP-10_", 270]
+      - ["^VSSOP-8_", 270]
+      - ["^TSOP-6", 270]
+      - ["^CP_EIA-", 180]
+      - ["^CP_Elec_8x10.5", 180]
+      - ["^CP_Elec_6.3x7.7", 180]
+      - ["^CP_Elec_8x6.7", 180]
+      - ["^CP_Elec_8x10", 180]
+      - ["^CP_Elec_10x10", 180]
+      - ["^(.*?_|V)?QFN-(16|20|24|28|40)(-|_|$)", 270]
+      - ["^Bosch_LGA-8_2x2.5mm_P0.65mm_ClockwisePinNumbering", 90]
+      - ["^PowerPAK_SO-8_Single", 270]
+      - ["^HTSSOP-28-1EP_4.4x9.7mm*", 270]
+      - ["^PUIAudio_SMT_0825_S_4_R*", 270]
+      - ["^USB_C_Receptacle_HRO_TYPE-C-31-M-12*", 180]
+      - ["ESP32-WROOM-32", 270]
+      - ["^SOIC127P798X216-8N", -90]
+      - ["^SW_DIP_SPSTx01_Slide_Copal_CHS-01B_W7.62mm_P1.27mm", -180]
+      - ["^BatteryHolder_Keystone_1060_1x2032", -180]
+      - ["^SO-14", -90]
+      - ["^HTSSOP-", 270]
+      - ["^USB_C_Receptacle_XKB_U262-16XN-4BVC11", 180]
+      - ["^Relay_DPDT_Omron_G6K-2F-Y", 270]
+      - ["^RP2040-QFN-56", 270]
+
+outputs:
+  - name: gerbers_jlcpcb
+    comment: Gerbers - JLCPCB
+    type: gerber
+    dir: gerber/jlcpcb
+    options: &gerber_options
+      exclude_edge_layer: true
+      exclude_pads_from_silkscreen: true
+      plot_sheet_reference: false
+      plot_footprint_refs: true
+      plot_footprint_values: false
+      force_plot_invisible_refs_vals: false
+      tent_vias: true
+      use_protel_extensions: false
+      create_gerber_job_file: false
+      disable_aperture_macros: true
+      gerber_precision: 4.6
+      use_gerber_x2_attributes: false
+      use_gerber_net_attributes: false
+      line_width: 0.1
+      subtract_mask_from_silk: true
+    layers:
+      - copper
+      - F.SilkS
+      - B.SilkS
+      - In1.Cu
+      - In2.Cu
+      - F.Mask
+      - B.Mask
+      - Edge.Cuts
+
+  - name: drill_jlcpcb
+    comment: Drill - JLCPCB
+    type: excellon
+    dir: gerber/jlcpcb
+    options:
+      pth_and_npth_single_file: false
+      pth_id: "PTH"
+      npth_id: "NPTH"
+      metric_units: false
+
+  - name: pap_jlcpcb
+    comment: "Pick and place - JLCPCB"
+    type: position
+    dir: gerber/jlcpcb
+    options:
+      variant: rotated
+      output: "%f-%i_cpl.%x"
+      format: CSV
+      units: millimeters
+      separate_files_for_front_and_back: false
+      only_smd: true
+      columns:
+        - id: Ref
+          name: Designator
+        - Val
+        - Package
+        - id: PosX
+          name: "Mid X"
+        - id: PosY
+          name: "Mid Y"
+        - id: Rot
+          name: Rotation
+        - id: Side
+          name: Layer
+
+  - name: bom_jlcpcb
+    comment: "BOM - JLCPCB"
+    type: kibom
+    dir: gerber/jlcpcb
+    options:
+      format: 'CSV'
+      output: "%f-bom.%x"
+      conf:
+        hide_pcb_info: true
+        ref_separator: ','
+        columns:
+          - field: Value
+            name: Comment
+            join: Description
+          - field: References
+            name: Designator
+          - Footprint
+          - field: "LCSC"
+            name: "LCSC Part #"
+
+  - name: mfg_jlcpcb
+    comment: create zip file for jlcpcb
+    type: compress
+    options:
+      files:
+        - from_output: gerbers_jlcpcb
+          dest: /gerbers
+        - from_output: drill_jlcpcb
+          dest: /gerbers
+        - from_output: pap_jlcpcb
+          dest: /
+        - from_output: bom_jlcpcb
+          dest: /

--- a/.kibot/mfg_modern.kibot.yaml
+++ b/.kibot/mfg_modern.kibot.yaml
@@ -1,0 +1,79 @@
+# This is a working example.
+# For a more complete reference use `--example`
+kibot:
+  version: 1
+
+
+outputs:
+- name: gerber_modern
+  comment: Gerbers in modern format, recommended by the standard
+  type: gerber
+  dir: gerber/modern
+  layers:
+  - layer: User.Comments
+    suffix: User_Comments
+    description: v-cuts
+  - layer: User.Drawings
+    suffix: User_Drawings
+    description: User Drawings
+  - layer: F.Cu
+    suffix: F_Cu
+    description: Front copper
+  - layer: In1.Cu
+    suffix: In1_Cu
+    description: Inner layer 1
+  - layer: In2.Cu
+    suffix: In2_Cu
+    description: Inner layer 2
+  - layer: B.Cu
+    suffix: B_Cu
+    description: Bottom copper
+  - layer: F.Adhesive
+    suffix: F_Adhesive
+    description: Front adhesive (glue)
+  - layer: F.Paste
+    suffix: F_Paste
+    description: Front solder paste
+  - layer: B.Paste
+    suffix: B_Paste
+    description: Back solder paste
+  - layer: B.Silkscreen
+    suffix: B_Silkscreen
+    description: Bottom silkscreen (artwork)
+  - layer: F.Silkscreen
+    suffix: F_Silkscreen
+    description: Front silkscreen (artwork)
+  - layer: B.Mask
+    suffix: B_Mask
+    description: Bottom soldermask (negative)
+  - layer: F.Mask
+    suffix: F_Mask
+    description: Front soldermask (negative)
+  - layer: User.Eco1
+    suffix: User_Eco1
+    description: For user usage 1
+  - layer: Edge.Cuts
+    suffix: Edge_Cuts
+    description: Board shape
+  - layer: F.Courtyard
+    suffix: F_Courtyard
+    description: Front courtyard area
+  - layer: F.Fab
+    suffix: F_Fab
+    description: Front documentation
+
+- name: mfg_modern
+  comment: create zip file modern x3 gerbers
+  type: compress
+  options:
+    files:
+      - from_output: gerber_modern
+        dest: /gerbers
+      - from_output: basic_gerb_drill
+        dest: /gerbers
+      - from_output: basic_excellon
+        dest: /gerbers
+      - from_output: basic_position_CSV
+        dest: /gerbers
+      - from_output: report_full
+        dest: /

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: bom clean docker_run build-pcb output/version.txt board_render.png board_render_purple.png
+
+GIT_VERSION := $(shell git describe --tags --always)
+PYTHON := python3
+OUTPUT_DIR := output
+OUTPUT_FILE := $(OUTPUT_DIR)/bitaxeGamma-$(GIT_VERSION).zip
+LOGFILE?=$(OUTPUT_DIR)/kibot_error.log
+DOCKER_IMAGE := registry.gitlab.com/nlighten-systems/kicad_ci:kicad_ci
+
+all: build-pcb
+
+clean:
+	rm -rf output
+
+docker_run:
+	docker run --rm -it -u "$(shell id -u):$(shell id -g)" -v "$(abspath .):/data" ${DOCKER_IMAGE} /bin/bash
+
+output:
+	mkdir -p output
+
+output/version.txt: | output
+	echo "$(GIT_VERSION)" > $@
+
+build-pcb: output/version.txt
+	kibot -d output -c kibot.yaml -e bitaxeGamma.kicad_sch
+

--- a/kibot.yaml
+++ b/kibot.yaml
@@ -1,0 +1,57 @@
+kibot:
+  version: 1
+
+import:
+  - file: .kibot/mfg_common.kibot.yaml
+  - file: .kibot/mfg_modern.kibot.yaml
+  - file: .kibot/mfg_jlcpcb.kibot.yaml
+
+preflight:
+  erc: false
+  drc: false
+  update_xml: true
+  check_zone_fills: true
+  set_text_variables:
+    - name: GIT_VERSION
+      command: git describe --tags --always
+    - name: DATE
+      expand_kibot_patterns: true
+      text: '%D'
+
+outputs:
+- name: generic_bom_csv
+  comment: Generic Bill of Materials in CSV format
+  type: kibom
+  dir: BoM
+  options:
+    format: 'CSV'
+
+- name: ibom
+  comment: Interactive bom
+  type: ibom
+  dir: BoM/html
+
+- name: basic_pdf_sch_print
+  comment: Schematic in PDF format
+  type: pdf_sch_print
+  dir: Schematic
+
+- name: basic_pcbdraw_png_purple_bottom
+  comment: PCB 2D render in PNG format, using purple style
+  type: pcbdraw
+  dir: PCB/2D_render/purple
+  options:
+    style: oshpark-purple
+    format: png
+    bottom: true
+    no_drillholes: true
+
+- name: basic_pcbdraw_png_purple_top
+  comment: PCB 2D render in PNG format, using purple style
+  type: pcbdraw
+  dir: PCB/2D_render/purple
+  options:
+    style: oshpark-purple
+    format: png
+    bottom: false
+    no_drillholes: true


### PR DESCRIPTION
This change adds Kicad CI automation using [KiBot](https://github.com/INTI-CMNB/KiBot). The default workflow generated manufacturing output like gerbers, dril files, and BOM files. It also has other various reports, schematic PDF, board render pictures, etc.